### PR TITLE
ZCS-13864 : Onlyoffice logo reset it back to show

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -16,7 +16,7 @@ all: clean zimbra-onlyoffice-pkg
 ########################################################################################################
 
 ONLY_OFFICE_VERSION = 1.0
-ONLY_OFFICE_URL="https://files.zimbra.com/downloads/onlyoffice/u14/zimbra-onlyoffice-v7.2.1.tar.gz"
+ONLY_OFFICE_URL="https://files.zimbra.com/downloads/onlyoffice/u14/zimbra-onlyoffice-v7.2.2.56.tar.gz"
 
 stage-zimbra-onlyoffice-pkg: downloads
 	mkdir -p build/stage/zimbra-onlyoffice/opt/zimbra
@@ -32,6 +32,7 @@ zimbra-onlyoffice-pkg: stage-zimbra-onlyoffice-pkg
 	--pkg-name=zimbra-onlyoffice \
 	--out-type=binary \
 	--pkg-summary="Zimbra onlyoffice package" \
+	--pkg-pre-install-script='scripts/preinst.sh' \
 	--pkg-post-install-script='scripts/postinst.sh' \
 	--pkg-installs='/opt/zimbra/onlyoffice/*'
 		

--- a/scripts/postinst.sh
+++ b/scripts/postinst.sh
@@ -6,6 +6,11 @@ if [ -f /opt/zimbra/onlyoffice/bin/zmonlyofficeconfig ]; then
 	chmod +x /opt/zimbra/onlyoffice/bin/zmonlyofficeconfig
 fi
 
+if [ -f /opt/zimbra/onlyoffice/bin/process_id.json.bak ]; then
+	mv -f /opt/zimbra/onlyoffice/bin/process_id.json.bak /opt/zimbra/onlyoffice/bin/process_id.json
+	/opt/zimbra/onlyoffice/bin/zmonlyofficeconfig
+fi
+
 if [ -f /opt/zimbra/onlyoffice/bin/process_id.json ]; then
 	chmod 775 /opt/zimbra/onlyoffice/bin/process_id.json
 	chown zimbra:zimbra /opt/zimbra/onlyoffice/bin/process_id.json

--- a/scripts/preinst.sh
+++ b/scripts/preinst.sh
@@ -1,0 +1,5 @@
+if [ -f /opt/zimbra/onlyoffice/bin/process_id.json ]; then
+	cp -af /opt/zimbra/onlyoffice/bin/process_id.json /opt/zimbra/onlyoffice/bin/process_id.json.bak
+	chmod 775 /opt/zimbra/onlyoffice/bin/process_id.json.bak
+	chown zimbra:zimbra /opt/zimbra/onlyoffice/bin/process_id.json.bak
+fi


### PR DESCRIPTION
**Problem:**

Updated tar file for the Onlyoffice logo.
After upgrading the zimbra-onlyoffice package onlyoffice services are not starting and throwing below error.

```
$ zmonlyofficectl start
Starting ...
Starting rabbitmq.....rabbitmq is running
zimbra@qa-zimbra12:~$ internal/fs/utils.js:332
    throw err;
    ^

Error: ENOENT: no such file or directory, open
    at Object.openSync (fs.js:498:3)
    at Object.openSync (pkg/prelude/bootstrap.js:796:32)
    at Object.readFileSync (fs.js:394:35)
    at Object.readFileSync (pkg/prelude/bootstrap.js:1082:36)
    at Object.<anonymous> (/snapshot/server/build/server/DocService/sources/server.js)
    at Module._compile (pkg/prelude/bootstrap.js:1930:22)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at Module.load (internal/modules/cjs/loader.js:950:32)
    at Function.Module._load (internal/modules/cjs/loader.js:790:12)
    at Function.runMain (pkg/prelude/bootstrap.js:1983:12)
    at internal/main/run_main_module.js:17:47 {
  errno: -2,
  syscall: 'open',
  code: 'ENOENT'
}
```
 This is due to some config files and process_id.json are overriding with zimbra-onlyoffice package upgrade. This has been fixed as part of this ticket.

**Tested below paths** (Rocky Linux 8, Ubuntu18) :

- Fresh Install setup with latest zimbra-onlyoffice package changes.
- Fresh Install setup with old zimbra-onlyoffice package -> Upgrade to the latest zimbra-onlyoffice package changes.