### PR TITLE
ZCS-13986: Added support for Ubuntu 22 and Rockylinux 9 in circle-ci config.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,17 @@ jobs:
       resource_class: small
       <<: *checkout_job_steps
 
+   build_u22:
+      working_directory: ~/zm-onlyoffice
+      shell: /bin/bash -eo pipefail
+      docker:
+         - image: $DOCKER_REGISTRY/zm-base-os:devcore-ubuntu-22.04
+           auth:
+            username: $DOCKER_USER
+            password: $DOCKER_PASS
+      resource_class: small
+      <<: *build_job_steps
+
    build_u20:
       working_directory: ~/zm-onlyoffice
       shell: /bin/bash -eo pipefail
@@ -82,6 +93,16 @@ jobs:
       resource_class: small
       <<: *build_job_steps
 
+   build_c9:
+      working_directory: ~/zm-onlyoffice
+      shell: /bin/bash -eo pipefail
+      docker:
+         - image: $DOCKER_REGISTRY/zm-base-os:devcore-centos-9
+           auth:
+            username: $DOCKER_USER
+            password: $DOCKER_PASS
+      resource_class: small
+      <<: *build_job_steps
 
    build_c8:
       working_directory: ~/zm-onlyoffice
@@ -115,12 +136,22 @@ workflows:
          - checkout:
             requires:
              - build
+         - build_u22:
+            requires:
+               - checkout
+            context:
+               - docker-dev-registry
          - build_u20:
             requires:
                - checkout
          - build_u18:
             requires:
                - checkout
+         - build_c9:
+            requires:
+               - checkout
+            context:
+               - docker-dev-registry
          - build_c8:
             requires:
                - checkout
@@ -130,8 +161,10 @@ workflows:
          - deploy_s3_hold:
             type: approval
             requires:
+               - build_u22
                - build_u20
                - build_u18
+               - build_c9
                - build_c8
                - build_c7
 


### PR DESCRIPTION
**ZCS-13986: Added support for Ubuntu 22 and Rockylinux 9 in circle-ci config.**

- Updated the circle-ci config.yaml file with new job to build Ubuntu 22 and Rockylinux 9  packages.
- Included the job into available workflows.

**Note**
- For all OS versions other than  Ubuntu 22 and Rockylinux 9  we are pulling images from zimbra/ public docker image registry.
- For Ubuntu 22 and Rockylinux 9 version we are pulling the base image from private docker dev images registry.
- Thats why I have added the `contexts: docker-dev-registry` in the workflow.